### PR TITLE
Add StoryContent styles and update widget classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hat-ring-components",
-    "version": "4.1.1",
+    "version": "4.2.1",
     "description": "Head App Template - RING components",
     "license": "MIT",
     "repository": {},

--- a/src/components/widgets/Story/StoryContent/StoryContent.astro
+++ b/src/components/widgets/Story/StoryContent/StoryContent.astro
@@ -4,6 +4,7 @@ import {default as StoryContentSwitcher} from "./StoryContentSwitcher.astro";
 import {WidgetHelper_getWidgetCssClasses} from "../../../../helpers/WidgetHelper";
 import {StoryContent_getData} from "./StoryContentGetData";
 import _ from 'lodash';
+import styles from "../../../../../styles/widgets/Story/StoryContent.module.scss";
 
 const response = await StoryContent_getData(context, widgetConfig);
 const content = _.get(response, 'data.story.content[0].blocks');
@@ -11,7 +12,7 @@ const flags = _.get(response, 'data.story.flags', []).map(flag => `flag_${flag.c
 ---
 
 
-<div class={WidgetHelper_getWidgetCssClasses('StoryContent', widgetConfig, context, flags)}>
+<div class={WidgetHelper_getWidgetCssClasses('StoryContent', widgetConfig, context, [...flags, styles.StoryContent])}>
     <StoryContentSwitcher content={content} widgetConfig={widgetConfig} context={context}
                           extendableAttributes={extendableAttributes}/>
 </div>

--- a/styles/widgets/Story/StoryContent.module.scss
+++ b/styles/widgets/Story/StoryContent.module.scss
@@ -1,0 +1,25 @@
+.StoryContent {
+    :global {
+        .TableBlock {
+            .alignLEFT {
+                text-align: left;
+            }
+
+            .alignCENTER {
+                text-align: center;
+            }
+
+            .alignRIGHT {
+                text-align: right;
+            }
+
+            .bold {
+                font-weight: bold;
+            }
+
+            .italic {
+                font-style: italic;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduces StoryContent.module.scss with table block styles and imports it into StoryContent.astro. The StoryContent widget now applies the new CSS module class alongside existing classes. Version bumped to 4.2.1 in package.json.