### PR TITLE
Support excluded categories for RSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hat-ring-components",
-    "version": "4.12.0",
+    "version": "4.13.0",
     "description": "Head App Template - RING components",
     "license": "MIT",
     "repository": {},

--- a/src/configs/SEOWebsitesConfig.ts
+++ b/src/configs/SEOWebsitesConfig.ts
@@ -317,8 +317,8 @@ export let SEOWebsitesConfig
             },
             "excludedCategoriesId": {
                 "type": "treeobject",
-                "name": "Excluded categories id",
-                "description": "Categories excluded from rss",
+                "name": "Excluded category IDs",
+                "description": "Categories excluded from RSS",
                 "properties": [
                     {
                         "name": "excludedCategoryId",

--- a/src/configs/SEOWebsitesConfig.ts
+++ b/src/configs/SEOWebsitesConfig.ts
@@ -52,7 +52,7 @@ export let SEOWebsitesConfig
                         "rssDefault.rssType",
                         "rssDefault.limit",
                         "rssDefault.excludedFlags",
-                        "rssDefault.excludedCategoriesId",
+                        "rssDefault.excludedCategoryIds",
                     ]
                 },
                 "seoOpenGraph": {
@@ -315,7 +315,7 @@ export let SEOWebsitesConfig
                     }
                 ]
             },
-            "excludedCategoriesId": {
+            "excludedCategoryIds": {
                 "type": "treeobject",
                 "name": "Excluded categories id",
                 "description": "Categories excluded from rss",

--- a/src/configs/SEOWebsitesConfig.ts
+++ b/src/configs/SEOWebsitesConfig.ts
@@ -52,6 +52,7 @@ export let SEOWebsitesConfig
                         "rssDefault.rssType",
                         "rssDefault.limit",
                         "rssDefault.excludedFlags",
+                        "rssDefault.excludedCategoriesId",
                     ]
                 },
                 "seoOpenGraph": {
@@ -123,6 +124,7 @@ export let SEOWebsitesConfig
             "rssType": "RSS 2.0 feed",
             "limit": 10,
             "excludedFlags": [],
+            "excludedCategoriesId": [],
         },
         "seoOpenGraph": {
             "imageSizesDesktop": "1200x630",
@@ -309,6 +311,17 @@ export let SEOWebsitesConfig
                 "properties": [
                     {
                         "name": "excludedFlag",
+                        "type": "textfield"
+                    }
+                ]
+            },
+            "excludedCategoriesId": {
+                "type": "treeobject",
+                "name": "Excluded categories id",
+                "description": "Categories excluded from rss",
+                "properties": [
+                    {
+                        "name": "excludedCategoryId",
                         "type": "textfield"
                     }
                 ]

--- a/src/configs/SEOWebsitesConfig.ts
+++ b/src/configs/SEOWebsitesConfig.ts
@@ -124,7 +124,7 @@ export let SEOWebsitesConfig
             "rssType": "RSS 2.0 feed",
             "limit": 10,
             "excludedFlags": [],
-            "excludedCategoriesId": [],
+            "excludedCategoryIds": [],
         },
         "seoOpenGraph": {
             "imageSizesDesktop": "1200x630",

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -101,7 +101,7 @@ export async function ConfigHelper_getSeoRssDefaultConfig(context): Promise<{
     rssType: string,
     limit: number,
     excludedFlags?: Array<{excludedFlag: string}>
-    excludedCategoriesId?: Array<{excludedCategoryId: string}>
+    excludedCategoryIds?: Array<{excludedCategoryId: string}>
 }> {
     return ConfigHelper_getConfig(context, 'rssDefault');
 }

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -101,6 +101,7 @@ export async function ConfigHelper_getSeoRssDefaultConfig(context): Promise<{
     rssType: string,
     limit: number,
     excludedFlags?: Array<{excludedFlag: string}>
+    excludedCategoriesId?: Array<{excludedCategoryId: string}>
 }> {
     return ConfigHelper_getConfig(context, 'rssDefault');
 }

--- a/src/renderlessComponents/seo/RSS/RSS.ts
+++ b/src/renderlessComponents/seo/RSS/RSS.ts
@@ -46,12 +46,16 @@ export async function RSS({context, feedDecorator, blockDecorator}: { context: A
     const excludedFlags = seoRssConfig.excludedFlags ? seoRssConfig.excludedFlags.map(flag => {
         return flag.excludedFlag
     }) : null;
+    const excludedCategoriesId = seoRssConfig.excludedCategoriesId ? seoRssConfig.excludedCategoriesId.map(category => {
+        return category.excludedCategoryId
+    }) : null;
 
     const variables = {
         categoryId: categoryId,
         limit: limit,
         offset,
-        excludedFlags
+        excludedFlags,
+        excludedCategoriesId: excludedCategoriesId
     };
 
     const response = await WebsiteApiProvider.call(query, variables, 60 * 10) as {

--- a/src/renderlessComponents/seo/RSS/RSS.ts
+++ b/src/renderlessComponents/seo/RSS/RSS.ts
@@ -46,7 +46,7 @@ export async function RSS({context, feedDecorator, blockDecorator}: { context: A
     const excludedFlags = seoRssConfig.excludedFlags ? seoRssConfig.excludedFlags.map(flag => {
         return flag.excludedFlag
     }) : null;
-    const excludedCategoriesId = seoRssConfig.excludedCategoriesId ? seoRssConfig.excludedCategoriesId.map(category => {
+    const excludedCategoryIds = seoRssConfig.excludedCategoryIds ? seoRssConfig.excludedCategoryIds.map(category => {
         return category.excludedCategoryId
     }) : null;
 
@@ -55,7 +55,7 @@ export async function RSS({context, feedDecorator, blockDecorator}: { context: A
         limit: limit,
         offset,
         excludedFlags,
-        excludedCategoriesId: excludedCategoriesId
+        excludedCategoryIds: excludedCategoryIds
     };
 
     const response = await WebsiteApiProvider.call(query, variables, 60 * 10) as {

--- a/src/renderlessComponents/seo/RSS/RSSGqlQuery.ts
+++ b/src/renderlessComponents/seo/RSS/RSSGqlQuery.ts
@@ -2,8 +2,8 @@ import {gql} from "graphql-tag";
 import {StoryHelper_getGqlContentFragment} from "../../../helpers/StoryHelper";
 
 export const RSSGqlQuery = gql`
-    query($categoryId: UUID!, $limit: Int!, $offset: Int!, $excludedFlags: [String!]){
-        stories(filter:{category: {in: [$categoryId]}, flag:{notIn:$excludedFlags}}, limit: $limit, offset: $offset ){
+    query($categoryId: UUID!, $limit: Int!, $offset: Int!, $excludedFlags: [String!], $excludedCategoriesId: [UUID!]){
+        stories(filter:{category: {in: [$categoryId], notIn: $excludedCategoriesId}, flag:{notIn:$excludedFlags}}, limit: $limit, offset: $offset ){
             total
             edges {
                 node {

--- a/src/renderlessComponents/seo/RSS/RSSGqlQuery.ts
+++ b/src/renderlessComponents/seo/RSS/RSSGqlQuery.ts
@@ -2,8 +2,8 @@ import {gql} from "graphql-tag";
 import {StoryHelper_getGqlContentFragment} from "../../../helpers/StoryHelper";
 
 export const RSSGqlQuery = gql`
-    query($categoryId: UUID!, $limit: Int!, $offset: Int!, $excludedFlags: [String!], $excludedCategoriesId: [UUID!]){
-        stories(filter:{category: {in: [$categoryId], notIn: $excludedCategoriesId}, flag:{notIn:$excludedFlags}}, limit: $limit, offset: $offset ){
+    query($categoryId: UUID!, $limit: Int!, $offset: Int!, $excludedFlags: [String!], $excludedCategoryIds: [UUID!]){
+        stories(filter:{category: {in: [$categoryId], notIn: $excludedCategoryIds}, flag:{notIn:$excludedFlags}}, limit: $limit, offset: $offset ){
             total
             edges {
                 node {


### PR DESCRIPTION
Allow excluding categories from RSS feeds. Adds a new excludedCategoriesId config entry to SEOWebsitesConfig (treeobject with excludedCategoryId), updates ConfigHelper type to include excludedCategoriesId, maps and passes excludedCategoriesId from the RSS component to the API, and extends the GraphQL query to accept $excludedCategoriesId: [UUID!] and apply it to stories.filter.category.notIn.