### PR TITLE
Defer image resize; add SEO author fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hat-ring-components",
-    "version": "4.13.0",
+    "version": "4.13.1",
     "description": "Head App Template - RING components",
     "license": "MIT",
     "repository": {},

--- a/src/components/common/RingImage.astro
+++ b/src/components/common/RingImage.astro
@@ -17,12 +17,6 @@ let src = props.src;
 let transform = props.transform || TransformType.None;
 
 let toRender: boolean | string | JSX.Element = false;
-const ext = UtilsHelper_getExtension(src);
-const isResizeable = ext != 'svg';
-
-if (isResizeable && transform !== TransformType.None) {
-    src = AcceleratorImagesHelper_getUrl(src, props.width, props.height, props.transform);
-}
 
 if (!src) {
     toRender = WidgetHelper_renderEmptyComponent('RingImage', 'Missing `src` value');
@@ -30,6 +24,15 @@ if (!src) {
 
 if (!props.width || !props.height) {
     toRender = WidgetHelper_renderEmptyComponent('RingImage', 'Missing `width` or `height` value');
+}
+
+if (!toRender) {
+    const ext = UtilsHelper_getExtension(src);
+    const isResizeable = ext != 'svg';
+
+    if (isResizeable && transform !== TransformType.None) {
+        src = AcceleratorImagesHelper_getUrl(src, props.width, props.height, props.transform);
+    }
 }
 
 ---

--- a/src/components/seo/SchemaOrg/SchemaOrg.astro
+++ b/src/components/seo/SchemaOrg/SchemaOrg.astro
@@ -14,7 +14,11 @@ import {
 import {gql} from "graphql-tag";
 import {WebsiteApiProvider} from "../../../providers/WebsiteApiProvider";
 import _ from "lodash";
-import {ConfigHelper_currentUrl, ConfigHelper_getHomepageUrl} from "../../../helpers/ConfigHelper";
+import {
+    ConfigHelper_currentUrl,
+    ConfigHelper_getHomepageUrl,
+    ConfigHelper_getSeoGeneralConfig
+} from "../../../helpers/ConfigHelper";
 import {Author} from "@ringpublishing/graphql-api-client-got/lib/types/websites-api";
 
 import {Breadcrumb} from "../../widgets/common/Breadcrumbs/types";
@@ -120,7 +124,21 @@ export async function getNewsArticleSchema(context: AppContext): Promise<WithCon
             "@type": "Person",
             "name": authorObj.author.name
         }
-    })
+    });
+
+    if (authors.length <= 0) {
+        const seoGeneralConfig = await ConfigHelper_getSeoGeneralConfig(context);
+        if (seoGeneralConfig.defaultArticleAuthor) {
+            const defaultAuthor:{name:string, email?: string} = {
+                name: seoGeneralConfig.defaultArticleAuthor
+            };
+
+            if (seoGeneralConfig.defaultArticleAuthorEmail) {
+                defaultAuthor.email = seoGeneralConfig.defaultArticleAuthorEmail;
+            }
+        }
+    }
+
 
     const dateModified = _.get(response, 'data.story.date.modificationTime') || _.get(response, 'data.story.date.creationTime');
     const datePublished = _.get(response, 'data.story.date.creationTime');
@@ -143,7 +161,7 @@ export async function getNewsArticleSchema(context: AppContext): Promise<WithCon
         "image": [_.get(response, 'data.story.image.url', '')],
         "datePublished": datePublished,
         "dateModified": dateModified,
-        "author": authors,
+        "author": authors.length <= 0 ? null : authors,
         "publisher": {
             "@type": "Organization",
             "name": await SeoHelper_currentSiteName(context),


### PR DESCRIPTION
RingImage: Delay extension detection and AcceleratorImagesHelper_getUrl call until after validation (ensures resizing only runs when component will render and required props are present).

SchemaOrg: Import ConfigHelper_getSeoGeneralConfig and, when no article authors are returned, read defaultArticleAuthor/defaultArticleAuthorEmail from the SEO config and construct a defaultAuthor object as a potential fallback. Also change the generated schema to set "author" to null when no authors are available.