### PR TITLE
Add tag TTL/refresh and cleanup for Redis cache

### DIFF
--- a/src/providers/RedisProvider.ts
+++ b/src/providers/RedisProvider.ts
@@ -16,6 +16,9 @@ interface RedisCacheValue {
     tags?: string[];
 }
 
+const DEFAULT_TAG_TTL_SECONDS = 60;
+const DEFAULT_TAG_REFRESH_INTERVAL_SECONDS = 3600;
+
 export class RedisProvider {
     client: RedisClientType;
     url: string;
@@ -39,8 +42,14 @@ export class RedisProvider {
         this.maxReInitialize = 10;
         this.currentReInitialize = 0;
         this.isReconnecting = false;
-        this.tagTTL = Number(process.env.CACHE_TAG_TTL || process.env.CACHE_TTL || 65000);
-        this.tagRefreshInterval = Number(process.env.CACHE_TAG_REFRESH_INTERVAL || 3600) * 1000; // default 1h in ms
+        this.tagTTL = this._parsePositiveIntOrDefault(
+            process.env.CACHE_TAG_TTL ?? process.env.CACHE_TTL,
+            DEFAULT_TAG_TTL_SECONDS
+        );
+        this.tagRefreshInterval = this._parsePositiveIntOrDefault(
+            process.env.CACHE_TAG_REFRESH_INTERVAL,
+            DEFAULT_TAG_REFRESH_INTERVAL_SECONDS
+        ) * 1000; // ms
         this.lastTagRefresh = new Map();
 
         setInterval(async () => {
@@ -365,6 +374,11 @@ export class RedisProvider {
                 expirationTimestamp: undefined,
             }
         }
+    }
+
+    _parsePositiveIntOrDefault(value: string | undefined, fallback: number): number {
+        const parsedValue = Number.parseInt(value || '', 10);
+        return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : fallback;
     }
 
     /**

--- a/src/providers/RedisProvider.ts
+++ b/src/providers/RedisProvider.ts
@@ -13,6 +13,7 @@ interface RedisCacheValue {
     data: string;
     ttl: number | undefined;
     expirationTimestamp: number | undefined;
+    tags?: string[];
 }
 
 export class RedisProvider {
@@ -25,6 +26,9 @@ export class RedisProvider {
     maxReInitialize: number;
     currentReInitialize: number;
     isReconnecting: boolean;
+    tagTTL: number;
+    tagRefreshInterval: number;
+    lastTagRefresh: Map<string, number>;
 
     constructor() {
         this.url = process.env.REDIS_RW;
@@ -35,6 +39,9 @@ export class RedisProvider {
         this.maxReInitialize = 10;
         this.currentReInitialize = 0;
         this.isReconnecting = false;
+        this.tagTTL = Number(process.env.CACHE_TAG_TTL || process.env.CACHE_TTL || 65000);
+        this.tagRefreshInterval = Number(process.env.CACHE_TAG_REFRESH_INTERVAL || 3600) * 1000; // default 1h in ms
+        this.lastTagRefresh = new Map();
 
         setInterval(async () => {
             if (!this.client) {
@@ -197,12 +204,14 @@ export class RedisProvider {
         if (ttl) {
             expirationTimestamp = Date.now() + ttl * 1000;
         }
-        const setValue = JSON.stringify({data: value, ttl, expirationTimestamp} as RedisCacheValue);
+        const tagsArray = (tags && typeof tags === 'object') ? tags as string[] : undefined;
+        const setValue = JSON.stringify({data: value, ttl, expirationTimestamp, tags: tagsArray} as RedisCacheValue);
         try {
             await this.client.set(key, setValue);
-            if (tags && typeof tags === 'object') {
-                for (const tag of tags) {
+            if (tagsArray) {
+                for (const tag of tagsArray) {
                     await this.client.sAdd('tag:' + tag, key);
+                    await this.client.expire('tag:' + tag, this.tagTTL);
                 }
             }
             MonitoringProvider.counter('info.RedisProvider.set');
@@ -225,6 +234,7 @@ export class RedisProvider {
                 return null;
             }
             const parsedData = this._parseResponse(data, key);
+            this._refreshTagsExpire(parsedData.tags);
             MonitoringProvider.counter('info.RedisProvider.get');
             return parsedData.data;
         } catch (err) {
@@ -247,6 +257,7 @@ export class RedisProvider {
                 return null;
             }
             const parsedData = this._parseResponse(data, key);
+            this._refreshTagsExpire(parsedData.tags);
             MonitoringProvider.counter('info.RedisProvider.getDecoratedCachedObject');
             return parsedData;
         } catch (err) {
@@ -356,6 +367,28 @@ export class RedisProvider {
         }
     }
 
+    /**
+     * Fire-and-forget: refresh EXPIRE on tag sets associated with a cached value.
+     * Keeps tags "hot" in LRU as long as their data keys are being read.
+     * Throttled per tag — only refreshes once per tagRefreshInterval (default 1h).
+     */
+    _refreshTagsExpire(tags?: string[]): void {
+        if (!tags || tags.length === 0 || !this.client) {
+            return;
+        }
+        const now = Date.now();
+        for (const tag of tags) {
+            const lastRefresh = this.lastTagRefresh.get(tag);
+            if (lastRefresh && (now - lastRefresh) < this.tagRefreshInterval) {
+                continue;
+            }
+            this.lastTagRefresh.set(tag, now);
+            this.client.expire('tag:' + tag, this.tagTTL).catch(() => {
+                // Silent fail — non-critical operation
+            });
+        }
+    }
+
 
     async stats() {
         if (!this.client) {
@@ -382,7 +415,37 @@ export class RedisProvider {
         if (!this.client) {
             await this.initialize();
         }
-        return await this.client.sMembers(`tag:${tag}`);
+        const keys = await this.client.sMembers(`tag:${tag}`);
+
+        if (!keys || keys.length === 0) {
+            return keys;
+        }
+
+        // Lazy cleanup: check which keys still exist in Redis
+        const existsResults = await Promise.all(
+            keys.map((key) => this.client.exists(key))
+        );
+
+        const aliveKeys: string[] = [];
+        const deadKeys: string[] = [];
+
+        for (let i = 0; i < keys.length; i++) {
+            if (existsResults[i]) {
+                aliveKeys.push(keys[i]);
+            } else {
+                deadKeys.push(keys[i]);
+            }
+        }
+
+        // Fire-and-forget: remove dead keys from the tag set
+        if (deadKeys.length > 0) {
+            MonitoringProvider.gauge('info.RedisProvider.getKeysByTag.staleKeysRemoved', deadKeys.length);
+            this.client.sRem(`tag:${tag}`, deadKeys).catch(() => {
+                MonitoringProvider.counter('error.RedisProvider.getKeysByTag.sRemFailed');
+            });
+        }
+
+        return aliveKeys;
     }
 
     async getValuesByTag(tag) {
@@ -405,6 +468,7 @@ export class RedisProvider {
 
     async addTag(tag, key) {
         await this.client.sAdd('tag:' + tag, key);
+        await this.client.expire('tag:' + tag, this.tagTTL);
     }
 
     async flushAllAsync(): Promise<any> {

--- a/src/providers/RedisProvider.ts
+++ b/src/providers/RedisProvider.ts
@@ -435,10 +435,12 @@ export class RedisProvider {
             return keys;
         }
 
-        // Lazy cleanup: check which keys still exist in Redis
-        const existsResults = await Promise.all(
-            keys.map((key) => this.client.exists(key))
-        );
+        // Lazy cleanup: check which keys still exist in Redis (single pipeline round-trip)
+        const pipeline = this.client.multi();
+        for (const key of keys) {
+            pipeline.exists(key);
+        }
+        const existsResults = (await pipeline.exec()) as unknown as number[];
 
         const aliveKeys: string[] = [];
         const deadKeys: string[] = [];


### PR DESCRIPTION
Add optional tags to cached values and manage tag lifecycle to avoid stale tag sets. Changes include:

- RedisCacheValue now includes an optional tags array.
- New config/state: tagTTL, tagRefreshInterval (default 1h), and lastTagRefresh map.
- When setting or adding a tag, set EXPIRE on the tag set so tag keys won't live forever.
- On reads (get / getDecoratedCachedObject) refresh tag EXPIREs via a new _refreshTagsExpire method, which is throttled per-tag and runs fire-and-forget.
- getKeysByTag now lazily filters out dead keys (checks existence), returns only alive keys, and asynchronously removes stale members from the tag set while emitting metrics for removals/failures.

These changes keep tag sets "hot" for LRU-friendly behavior, prevent accumulation of stale members, and throttle refresh calls to reduce Redis load.