### PR TITLE
feat: set cacheTtl=60s on category node GQL query in SeoTitleHelper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hat-ring-components",
-    "version": "4.14.0",
+    "version": "4.14.1",
     "description": "Head App Template - RING components",
     "license": "MIT",
     "repository": {},

--- a/src/helpers/seo/SeoTitleHelper.ts
+++ b/src/helpers/seo/SeoTitleHelper.ts
@@ -113,7 +113,7 @@ export async function SeoTitleHelper_pageTitle(context, place: string) {
         const nodeResponse = await WebsiteApiProvider.call(nodeQuery, {
             url: UtilsHelper_getDomain(context, true) + context.url,
             variant: context.websiteManagerVariant,
-        });
+        }, 60);
 
         const categoryName = _.get(nodeResponse, 'data.site.data.node.category.data.name', '');
         if (categoryName) return categoryName;


### PR DESCRIPTION
## Problem

The `getCategoryName()` function in `SeoTitleHelper.ts` fetches node/category data via a `site()` GraphQL query without an explicit `cacheTtl`. This means the cached response never expires (relies on the default global cache TTL), so changes to a category name — and therefore the page `<title>` — are not reflected until the cache is flushed or the server restarts.

## Change

Set `cacheTtl = 60` seconds on the `site()` query inside `getCategoryName()`.

```ts
// before
const nodeResponse = await WebsiteApiProvider.call(nodeQuery, { url, variant });

// after
const nodeResponse = await WebsiteApiProvider.call(nodeQuery, { url, variant }, 60);
```

The cache uses **stale-while-revalidate**: expired entries are served immediately while a background refresh is triggered, so there is no added latency.

## Why not story queries?

Story queries intentionally have **no explicit TTL** — their cache entries are invalidated by the notification handler on publish. Setting a TTL on them would cause stale content to be served for up to 60s after a publish event.

## Version

`4.14.0` → `4.14.1`