### PR TITLE
fix: correct GenericList pagination offset for postShift > 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hat-ring-components",
-    "version": "4.14.1",
+    "version": "4.14.2",
     "description": "Head App Template - RING components",
     "license": "MIT",
     "repository": {},

--- a/src/components/widgets/Lists/GenericList/GenericList.astro
+++ b/src/components/widgets/Lists/GenericList/GenericList.astro
@@ -22,9 +22,7 @@ const allGeneralParts = GeneralParts;
 let queryFragment = '';
 let response: any = null;
 
-const isAjaxCall = UtilsHelper_getQueryParam('gridLocationWidgetType', context) === 'genericList';
-const isFirstCall = UtilsHelper_getQueryParam('isFirstCall', context) === '1';
-const offset = WidgetHelper_calculateOffsetForGenericListPagination(widgetConfig, currentPage, isAjaxCall, isFirstCall);
+const offset = WidgetHelper_calculateOffsetForGenericListPagination(widgetConfig, currentPage);
 
 if (offset >= 1000) {
     toRender = `<script>

--- a/src/components/widgets/Lists/GenericList/GenericListGetData.ts
+++ b/src/components/widgets/Lists/GenericList/GenericListGetData.ts
@@ -97,9 +97,7 @@ export async function GenericList_getData(context: AppContext, queryNodeFragment
         return flag.excludedFlag
     }) : null;
 
-    const isAjaxCall = UtilsHelper_getQueryParam('gridLocationWidgetType', context) === 'genericList';
-    const isFirstCall = UtilsHelper_getQueryParam('isFirstCall', context) === '1';
-    const offset = WidgetHelper_calculateOffsetForGenericListPagination(widgetConfig, currentPage, isAjaxCall, isFirstCall);
+    const offset = WidgetHelper_calculateOffsetForGenericListPagination(widgetConfig, currentPage);
     const queryForDynamicName = getQueryForDynamicName(context, widgetConfig);
 
     const variables: any = {

--- a/src/components/widgets/Lists/GenericList/generalParts/InfiniteScrollButton.astro
+++ b/src/components/widgets/Lists/GenericList/generalParts/InfiniteScrollButton.astro
@@ -23,7 +23,6 @@ const noMoreItems = (response?.data?.stories?.edges?.length || 0) <= 0 || (respo
 
     <script define:vars={{buttonId, gridLocation: widgetConfig.gridLocation, isMainSeoList: widgetConfig.mainSeoList, widgetType: widgetConfig.widgetType}}>
         const button = document.getElementById(buttonId);
-        let isFirstCall = true;
         button.addEventListener('click', loadMore);
 
         const seoObserver = new IntersectionObserver(entries => {
@@ -54,12 +53,7 @@ const noMoreItems = (response?.data?.stories?.edges?.length || 0) <= 0 || (respo
                 ajaxNextPageUrl.searchParams.set('page', nextPage);
                 ajaxNextPageUrl.searchParams.set('gridLocation', gridLocation);
                 ajaxNextPageUrl.searchParams.set('gridLocationWidgetType', widgetType);
-                if (isFirstCall) {
-                    ajaxNextPageUrl.searchParams.set('isFirstCall', 1);
-                    isFirstCall = false;
-                } else {
-                    ajaxNextPageUrl.searchParams.delete('isFirstCall');
-                }
+
                 const fetchedData = await fetch(ajaxNextPageUrl.href);
                 const html = await fetchedData.text();
                 const parser = new DOMParser();

--- a/src/helpers/GenericListHelper.ts
+++ b/src/helpers/GenericListHelper.ts
@@ -1,22 +1,12 @@
 import {UtilsHelper_convertToInt, UtilsHelper_parsePositiveIntFromString} from "./UtilsHelper";
 import {GenericListWidgetConfig} from "../components/widgets/Lists/GenericList/types";
 const MAX_OFFSET = 1000;
-export function WidgetHelper_calculateOffsetForGenericListPagination(widgetConfig: GenericListWidgetConfig, currentPage: number, isAjaxCall: boolean, isFirstCall: boolean) {
+export function WidgetHelper_calculateOffsetForGenericListPagination(widgetConfig: GenericListWidgetConfig, currentPage: number) {
     const perPageAllItems = UtilsHelper_convertToInt(widgetConfig?.perPageAllItems) || UtilsHelper_convertToInt(widgetConfig?.paginationElements);
     const postShiftValue = UtilsHelper_convertToInt(widgetConfig?.postShift) || 0;
     currentPage = UtilsHelper_parsePositiveIntFromString(currentPage) || 1;
     const totalItemsBefore = perPageAllItems * (currentPage - 1);
-    let offset = 0;
-    if (isAjaxCall) {
-        if (isFirstCall) {
-            offset = totalItemsBefore;
-        } else {
-            const shiftAdjustment = postShiftValue * (currentPage - 2);
-            offset = totalItemsBefore - shiftAdjustment;
-        }
-    } else {
-        offset = totalItemsBefore + postShiftValue;
-    }
+    const offset = totalItemsBefore + postShiftValue;
 
     return Math.min(MAX_OFFSET - perPageAllItems, Math.max(0, offset));
 }

--- a/src/renderlessComponents/seo/SeoMetaData/SeoListGridPrevNext.ts
+++ b/src/renderlessComponents/seo/SeoMetaData/SeoListGridPrevNext.ts
@@ -29,9 +29,7 @@ export async function SeoListGridPrevNext(context: AppContext) {
         return {};
     }
     const currentPage = UtilsHelper_parsePositiveIntFromString(UtilsHelper_getQueryParam('page', context)) || 1;
-    const isAjaxCall = UtilsHelper_getQueryParam('gridLocationWidgetType', context) === 'genericList';
-    const isFirstCall = UtilsHelper_getQueryParam('isFirstCall', context) === '1';
-    const offset = WidgetHelper_calculateOffsetForGenericListPagination(foundGenericList, currentPage, isAjaxCall, isFirstCall);
+    const offset = WidgetHelper_calculateOffsetForGenericListPagination(foundGenericList, currentPage);
 
     if (offset >= MAX_OFFSET) {
         return {}


### PR DESCRIPTION
## Problem

When `postShift > 0` (e.g. aerotelegraph uses `postShift=3`), the GenericList infinite scroll pagination showed duplicate articles. The first 3 articles from each new page were the same as the last 3 from the previous page.

## Root Cause

Commit `2d30cdb` introduced `isAjaxCall`/`isFirstCall` branching in `WidgetHelper_calculateOffsetForGenericListPagination` that incorrectly omitted `postShift` from the offset calculation for AJAX calls. This was not caught because all other HAT projects use `postShift=0`, making all branches produce identical results.

## Fix

Simplified the offset formula to: `totalItemsBefore + postShiftValue` — removing the incorrect branching logic. The formula is now correct regardless of whether it's an SSR or AJAX call.

## Version

`4.14.1` → `4.14.2`